### PR TITLE
Migrate the Spell from commandline to filebased And accept XML 

### DIFF
--- a/dataweavetransformation/Dockerfile
+++ b/dataweavetransformation/Dockerfile
@@ -23,6 +23,7 @@ RUN cd cmd && go build -o dwadapter
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /app
+RUN microdnf install git
 ENV DW_HOME=/app/.dw
 ENV DW_LIB_PATH=/app/.dw/libs
 ENV PATH=/app/.dw/bin:$PATH

--- a/dataweavetransformation/Dockerfile
+++ b/dataweavetransformation/Dockerfile
@@ -23,7 +23,6 @@ RUN cd cmd && go build -o dwadapter
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /app
-RUN microdnf install git
 ENV DW_HOME=/app/.dw
 ENV DW_LIB_PATH=/app/.dw/libs
 ENV PATH=/app/.dw/bin:$PATH

--- a/dataweavetransformation/README.md
+++ b/dataweavetransformation/README.md
@@ -25,54 +25,108 @@ kubectl apply -f /config/200-deployment.yaml
 The DataweaveTransformation object will accept any event and use the Dataweave spell provided in the spec to transform it.
 If it was deployed with the example Dataweave spell, one can try the following example event:
 ```cmd
-curl --location --request POST  'http://dataweavetransformations-hello-dw.default.34.133.226.173.sslip.io' \
+curl --location --request POST 'http://dataweavetransformations-hello-dw.dw.35.202.146.138.sslip.io' \
 --header 'Ce-Specversion: 1.0' \
---header 'Ce-Type: io.triggermesh.sample.event' \
+--header 'Ce-Type: io.triggermesh.mongodb.query.kv' \
 --header 'Ce-Id: 123123' \
 --header 'Ce-Source: ser' \
 --header 'Content-Type: application/json' \
---data-raw '[
-  {
-    "name": "User1",
-    "age": 19
-  },
-  {
-    "name": "User2",
-    "age": 18
-  },
-  {
-    "name": "User3",
-    "age": 15
-  },
-  {
-    "name": "User4",
-    "age": 13
-  },
-  {
-    "name": "User5",
-    "age": 16
-  }
-]'
+--data-raw '{
+    "books": [
+      {
+        "-category": "cooking",
+        "title":"Everyday Italian",
+        "author": "Giada De Laurentiis",
+        "year": "2005",
+        "price": "30.00"
+      },
+      {
+        "-category": "children",
+        "title": "Harry Potter",
+        "author": "J K. Rowling",
+        "year": "2005",
+        "price": "29.99"
+      },
+      {
+        "-category": "web",
+        "title":  "XQuery Kick Start",
+        "author": [
+          "James McGovern",
+          "Per Bothner",
+          "Kurt Cagle",
+          "James Linn",
+          "Vaidyanathan Nagarajan"
+        ],
+        "year": "2003",
+        "price": "49.99"
+      },
+      {
+        "-category": "web",
+        "-cover": "paperback",
+        "title": "Learning XML",
+        "author": "Erik T. Ray",
+        "year": "2003",
+        "price": "39.95"
+      }
+    ]
+}'
 ```
 Expecting a response like this inside the logs of the event-display:
 ```
 ☁️  cloudevents.Event
 Context Attributes,
   specversion: 1.0
-  type: io.triggermesh.sample.event
-  source: ser
-  id: 8fca9e2d-d3ec-495d-a43d-3f00b3b73740
-  time: 2022-02-02T17:55:00.319205486Z
+  type: dev.knative.sources.ping
+  source: /apis/v1/namespaces/dw/pingsources/cj
+  id: 4c1a3770-cc4b-46b1-94b8-f50f9e918c50
+  time: 2022-02-03T19:25:00.094490019Z
   datacontenttype: application/json
 Data,
-[
   {
-    "name": "User1",
-    "age": 19
-  },
-  {
-    "name": "User2",
-    "age": 18
+    "items": [
+      {
+        "book": {
+          "-CATEGORY": "cooking",
+          "TITLE": "Everyday Italian",
+          "AUTHOR": "Giada De Laurentiis",
+          "YEAR": "2005",
+          "PRICE": "30.00"
+        }
+      },
+      {
+        "book": {
+          "-CATEGORY": "children",
+          "TITLE": "Harry Potter",
+          "AUTHOR": "J K. Rowling",
+          "YEAR": "2005",
+          "PRICE": "29.99"
+        }
+      },
+      {
+        "book": {
+          "-CATEGORY": "web",
+          "TITLE": "XQuery Kick Start",
+          "AUTHOR": [
+            "James McGovern",
+            "Per Bothner",
+            "Kurt Cagle",
+            "James Linn",
+            "Vaidyanathan Nagarajan"
+          ],
+          "YEAR": "2003",
+          "PRICE": "49.99"
+        }
+      },
+      {
+        "book": {
+          "-CATEGORY": "web",
+          "-COVER": "paperback",
+          "TITLE": "Learning XML",
+          "AUTHOR": "Erik T. Ray",
+          "YEAR": "2003",
+          "PRICE": "39.95"
+        }
+      }
+    ]
   }
-]
 ```

--- a/dataweavetransformation/README.md
+++ b/dataweavetransformation/README.md
@@ -76,8 +76,8 @@ Expecting a response like this inside the logs of the event-display:
 ☁️  cloudevents.Event
 Context Attributes,
   specversion: 1.0
-  type: dev.knative.sources.ping
-  source: /apis/v1/namespaces/dw/pingsources/cj
+  type: io.triggermesh.sample.event
+  source: ser
   id: 4c1a3770-cc4b-46b1-94b8-f50f9e918c50
   time: 2022-02-03T19:25:00.094490019Z
   datacontenttype: application/json

--- a/dataweavetransformation/README.md
+++ b/dataweavetransformation/README.md
@@ -27,7 +27,7 @@ If it was deployed with the example Dataweave spell, one can try the following e
 ```cmd
 curl --location --request POST 'http://dataweavetransformations-hello-dw.dw.35.202.146.138.sslip.io' \
 --header 'Ce-Specversion: 1.0' \
---header 'Ce-Type: io.triggermesh.mongodb.query.kv' \
+--header 'Ce-Type: io.triggermesh.sample.event' \
 --header 'Ce-Id: 123123' \
 --header 'Ce-Source: ser' \
 --header 'Content-Type: application/json' \

--- a/dataweavetransformation/config/101-instance.yaml
+++ b/dataweavetransformation/config/101-instance.yaml
@@ -17,7 +17,15 @@ kind: DataweaveTransformation
 metadata:
   name: hello-dw
 spec:
-  dw_spell: output application/json --- payload filter (item) -> item.age > 17
+  dw_spell: |-
+      %dw 2.0
+      output application/json
+      ---
+      items: payload.books map (item, index) -> {
+            book: item mapObject (value, key) -> {
+            (upper(key)): value
+            }
+      }
   output_content_type: application/json
   incoming_content_type: application/json
   sink:

--- a/dataweavetransformation/config/sample/300-dataweavetransformation.yaml
+++ b/dataweavetransformation/config/sample/300-dataweavetransformation.yaml
@@ -17,7 +17,15 @@ kind: DataweaveTransformation
 metadata:
   name: hello-dw
 spec:
-  dw_spell: output application/json --- payload filter (item) -> item.age > 17
+  dw_spell: |-
+      %dw 2.0
+      output application/json
+      ---
+      items: payload.books map (item, index) -> {
+            book: item mapObject (value, key) -> {
+            (upper(key)): value
+            }
+      }
   output_content_type: application/json
   incoming_content_type: application/json
   sink:

--- a/dataweavetransformation/config/sample/400-pingsource.yaml
+++ b/dataweavetransformation/config/sample/400-pingsource.yaml
@@ -17,7 +17,46 @@ kind: PingSource
 metadata:
     name: cj
 spec:
-    data: '[{  "name": "User1",  "age": 19},{  "name": "User2",  "age": 18},{  "name": "User3",  "age": 15},{  "name": "User4",  "age": 13},{  "name": "User5",  "age": 16}]'
+    data: |-
+        {
+            "books": [
+              {
+                "-category": "cooking",
+                "title":"Everyday Italian",
+                "author": "Giada De Laurentiis",
+                "year": "2005",
+                "price": "30.00"
+              },
+              {
+                "-category": "children",
+                "title": "Harry Potter",
+                "author": "J K. Rowling",
+                "year": "2005",
+                "price": "29.99"
+              },
+              {
+                "-category": "web",
+                "title":  "XQuery Kick Start",
+                "author": [
+                  "James McGovern",
+                  "Per Bothner",
+                  "Kurt Cagle",
+                  "James Linn",
+                  "Vaidyanathan Nagarajan"
+                ],
+                "year": "2003",
+                "price": "49.99"
+              },
+              {
+                "-category": "web",
+                "-cover": "paperback",
+                "title": "Learning XML",
+                "author": "Erik T. Ray",
+                "year": "2003",
+                "price": "39.95"
+              }
+            ]
+        }
     schedule: '*/1 * * * *'
     sink:
       ref:

--- a/dataweavetransformation/pkg/adapter/adapter.go
+++ b/dataweavetransformation/pkg/adapter/adapter.go
@@ -110,14 +110,14 @@ func (a *adapter) dispatch(ctx context.Context, event cloudevents.Event) (*cloud
 	var err error
 	var tmpfile *os.File
 	if a.incomingContentType == "application/json" {
-		tmpfile, err = ioutil.TempFile("/app", "*.xml")
+		tmpfile, err = ioutil.TempFile("/app", "*.json")
 		if err != nil {
 			return a.replier.Error(&event, targetce.ErrorCodeAdapterProcess, err, "creating the file")
 		}
 	}
 
 	if a.incomingContentType == "application/xml" {
-		tmpfile, err = ioutil.TempFile("/app", "*.json")
+		tmpfile, err = ioutil.TempFile("/app", "*.xml")
 		if err != nil {
 			return a.replier.Error(&event, targetce.ErrorCodeAdapterProcess, err, "creating the file")
 		}

--- a/dataweavetransformation/pkg/adapter/adapter.go
+++ b/dataweavetransformation/pkg/adapter/adapter.go
@@ -108,9 +108,19 @@ func (a *adapter) Start(ctx context.Context) error {
 
 func (a *adapter) dispatch(ctx context.Context, event cloudevents.Event) (*cloudevents.Event, cloudevents.Result) {
 	var err error
-	tmpfile, err := ioutil.TempFile("/app", "*.json")
-	if err != nil {
-		return a.replier.Error(&event, targetce.ErrorCodeAdapterProcess, err, "creating the file")
+	var tmpfile *os.File
+	if a.incomingContentType == "application/json" {
+		tmpfile, err = ioutil.TempFile("/app", "*.xml")
+		if err != nil {
+			return a.replier.Error(&event, targetce.ErrorCodeAdapterProcess, err, "creating the file")
+		}
+	}
+
+	if a.incomingContentType == "application/xml" {
+		tmpfile, err = ioutil.TempFile("/app", "*.json")
+		if err != nil {
+			return a.replier.Error(&event, targetce.ErrorCodeAdapterProcess, err, "creating the file")
+		}
 	}
 
 	if _, err := tmpfile.Write(event.Data()); err != nil {

--- a/dataweavetransformation/pkg/adapter/adapter.go
+++ b/dataweavetransformation/pkg/adapter/adapter.go
@@ -43,7 +43,7 @@ func EnvAccessorCtor() pkgadapter.EnvConfigAccessor {
 type envAccessor struct {
 	pkgadapter.EnvConfig
 	// Spell defines the Dataweave spell to use on the incoming data at the event payload.
-	Spell string `envconfig:"DW_SPELL" required:true`
+	Spell string `envconfig:"DW_SPELL" required:"true"`
 	// IncomingContentType defines the expected content type of the incoming data.
 	IncomingContentType string `envconfig:"INCOMING_CONTENT_TYPE" default:"application/json"`
 	// OutputContentType defines the content the cloudevent to be sent with the transformed data.

--- a/dataweavetransformation/pkg/adapter/adapter.go
+++ b/dataweavetransformation/pkg/adapter/adapter.go
@@ -69,7 +69,7 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 		logger.Panicf("Error creating CloudEvents replier: %v", err)
 	}
 
-	errs := registerAndPopulateSpell(env.Spell, logger)
+	errs := registerAndPopulateSpell(env.Spell)
 	if errs != nil {
 		logger.Panicf("Error creating spell: %v", errs)
 	}
@@ -143,7 +143,7 @@ func (a *adapter) dispatch(ctx context.Context, event cloudevents.Event) (*cloud
 	return &event, cloudevents.ResultACK
 }
 
-func registerAndPopulateSpell(spell string, logger *zap.SugaredLogger) error {
+func registerAndPopulateSpell(spell string) error {
 	if err := exec.Command("dw", "--new-spell", "custom").Run(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Upgrade the spell passing. allowing the use of full spells to be passed in and not limiting the user to passing it in via the command line. this enables more advanced spells to be processed. This also allows the adapter to accept XML Data.